### PR TITLE
Changed rhel version for LSO must-gather collection from 8 to 9

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -49,7 +49,7 @@ endif::openshift-rosa,openshift-dedicated[]
 |Data collection for OpenShift Shared Resource CSI Driver.
 
 ifndef::openshift-rosa,openshift-dedicated[]
-|`registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel8:v<installed_version_LSO>`
+|`registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v<installed_version_LSO>`
 |Data collection for Local Storage Operator.
 
 |`registry.redhat.io/openshift-sandboxed-containers/osc-must-gather-rhel8:v<installed_version_sandboxed_containers>`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Local Storage Operator must-gather image, since 4.15 , it is based on rhel9 instead of rhel8 which was for OCP 4.14 and lower versions.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
